### PR TITLE
Fix for #1, Don't process href too soon

### DIFF
--- a/src/download-polyfill.js
+++ b/src/download-polyfill.js
@@ -4,11 +4,13 @@ const msSaveBlob = typeof window.navigator.msSaveBlob !== 'undefined';
 if (!downloadAttributeSupport && msSaveBlob) {
 	document.addEventListener('click', (evt) => {
 		const { target } = evt;
-		const { tagName, href } = target;
-		const fileName = new URL(href).pathname.split('/').pop();
+		const { tagName } = target;
 
 		if (tagName === 'A' && target.hasAttribute('download')) {
 			evt.preventDefault();
+
+			const { href } = target;
+			const fileName = new URL(href).pathname.split('/').pop();
 
 			const xhr = new XMLHttpRequest();
 


### PR DESCRIPTION
## Changes

- Move the processing of the href attribute value to after we know it's dealing with an `<a>`

Fixes #1